### PR TITLE
wrong number of args with cli flag

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -80,7 +80,7 @@ func FromCli(c *cli.Context) (plugin.Middleware, error) {
 
 func CliFlags() []cli.Flag {
 	return []cli.Flag{
-		cli.StringFlag{"user, u", "", "Basic auth username"},
-		cli.StringFlag{"pass, p", "", "Basic auth pass"},
+		cli.StringFlag{"user, u", "", "Basic auth username", ""},
+		cli.StringFlag{"pass, p", "", "Basic auth pass", ""},
 	}
 }


### PR DESCRIPTION
Was playing with this and noticed it didn't compile.
Error: `vulcand-auth/auth/auth.go:84: too few values in struct initializer`

Looks like [a breaking change was made upstream](https://github.com/mailgun/vulcand/commit/8bf2e4235081533d297135fb8b462f98a4bd069b#diff-a9fc59ffe86918ec8fc644c65d622c2bR110) and not updated here.
